### PR TITLE
fix: `LbEntry` の仮定義

### DIFF
--- a/docs/schema.ts
+++ b/docs/schema.ts
@@ -1,3 +1,4 @@
+// @ts-ignore: temporally unavailable
 import { z } from "zod";
 
 // radwimpiece, radwimps / piece なので言語ごとの断片情報は "piece" である

--- a/docs/schema.ts
+++ b/docs/schema.ts
@@ -35,3 +35,7 @@ export type Leaderboard = {
 
   push: (e: LbEntry) => void;
 };
+
+type LbEntry = {
+  /* not defined */
+};


### PR DESCRIPTION
close #

<!--
    このプルリクエストに関連し、マージ時に自動的にクローズしたいIssueの番号を記載します。
    複数のIssueを記載する場合は、改行で区切ってください。
    例:
    close #1
    close #2
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

### Type of Change:

<!--
    案を実現するためにどういうタイプの変更を行ったのか
    e.g. 修正(fix), 新規追加(feat), 破壊的変更　など
-->

`docs/schema.ts` で参照されている `LbEntry` が定義されていなかったのでこれを修正した

### Cause of the Problem (問題の原因)

`docs/schema.ts` を書いたときは CI を走らせていなかったので確認してなかった

### Dealing with Problems (問題への対処)

<!-- 問題対処の方法についての複数の案とどれを採用したのか -->

空構造体の定義を行った (今後具体的な構造が決定してから追記するため)
`unknown` を使うことも考えられるが, まず概ね構造体であることが考えられる. それ且つ下手にプリミティブ単体を用いたり独自のデータ管理スキームを成り立たせることはコードの衛生を保つ上で不適と考えるため, まず構造体であることを確定させている

### Details of implementation (実施内容)

```
types LbEntry = {};
```

### Additional Information (追加情報)

これはうっかりミス
これを merge したら #9 も続けて merge するので #8 に差分取り込みをよろしくお願いします (でないと CI が通らないので) to @raiga0310 